### PR TITLE
(copilot) Refactor: replace val_to_X() and GET_ARG() with MRBC_ARG_X() and MRBC_TO_X()

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ platform = espressif32@6.10.0
 framework = espidf
 lib_deps = 
 	m5stack/M5Unified@0.2.7
-    https://github.com/mrubyc/mrubyc.git#2cbbbf757bbc9366fd319dd76753dc2c8b8386b9
+    https://github.com/mrubyc/mrubyc.git#690b38d05a3de78726cd2a228a84c209a21a737b
 build_flags =
 	-Isrc/lib/mrubyc
 	-I.pio/libdeps/${PIOENV}/mrubyc/src

--- a/sample_rb/demo.rb
+++ b/sample_rb/demo.rb
@@ -1,0 +1,152 @@
+white=0xffff
+blue=0x001f
+green=0x07e0
+purple=0xf81f
+red=0xf800
+cyan=0x07ff
+yellow=0xffe0
+black=0x0000
+gray=0x8410
+darkgray=0x4208
+lightgray=0xc618
+boards=[
+  "displayless","M5Stack","M5StackCore2","M5StickC","M5StickCPlus",
+  "M5StickCPlus2","M5StackCoreInk","M5Paper","M5Tough","M5Station",
+  "M5StackCoreS3","M5AtomS3","M5Dial","M5DinMeter","M5Cardputer",
+  "M5AirQ","M5VAMeter","M5StackCoreS3SE","M5AtomS3R",
+]
+
+def hit_any_key
+  M5.update
+  return (BtnA.is_pressed? or BtnB.is_pressed? or (Touch.count>0 and Touch.was_clicked?(0)) )
+end
+
+#
+while true do
+    puts "Hello demo"
+    board=M5.board
+    if board>127 then board=0 end
+    puts "Board: #{boards[board]}(#{board})"
+    Display.clear
+
+    if Speaker then
+    Speaker.volume = 20
+    Speaker.tone 1000,100,0
+    Speaker.tone 2000,100,0,false
+    end
+
+    Display.set_text_size(1) if Display.dimension[0]<240
+    Display.set_cursor(0,0)
+    Display.puts "Board: #{boards[board]}(#{board})"
+    Display.puts "Display: #{Display.dimension.inspect}"
+    Display.puts "Touch: " + ((Touch.available?)? "OK":"NG")
+    Display.puts
+
+    cur=Display.get_cursor
+    cur[0]+=12 if Display.dimension[0]>300
+    Display.set_cursor(*cur)
+    Display.set_text_size(4) if Display.dimension[0]>300
+    [["H",white,red],["e",white,green],["l",white,blue],["l",white,purple],["o",white,cyan], [" ",white,black], 
+    ["W",white,gray], ["o",white,darkgray], ["r",white,lightgray], ["l",white,white], ["d",white,black], ["!",white,red], ["\n",white,black]
+    ].each do |c|
+    Display.set_text_color(c[1],c[2])
+    Display.print c[0]
+    end
+
+    Display.set_text_size(2);
+    Display.set_text_color(0xffff)
+
+    sleep 1
+    Display.puts
+    Display.puts "Hit any key"
+    while !hit_any_key  do 
+        sleep 0.1 
+        return if Blink.req_reload?
+    end
+    Display.puts "!"
+
+    xscale=2.0
+    yscale=2.0
+    xoffset=0
+    yoffset=50
+    case board 
+        when 3,4,5 # M5StickC
+        xscale=0.6
+        yscale=0.6
+        xoffset=0
+        yoffset=80
+        when 11 #atomS3
+        xscale=0.8
+        yscale=0.8
+        yoffset=50
+    end
+
+    if board>0 then
+        puts "Mexican Hat"
+        Display.clear
+        Display.puts "Mexican Hat"
+        def dot(x,y,c)
+            Display.draw_line(x.to_i,y.to_i,x.to_i,y.to_i,c)
+        end
+
+        d=Array.new(160,100)
+
+        dr=3.141592/180
+        (-30..30).each do |by|
+            (-30..30).each do |bx|
+                x=bx*6; y=by*6
+                r=dr*Math.sqrt(x*x+y*y)
+                z=100*Math.cos(r) - 30*Math.cos(3*r)
+                sx=(80+x/3-y/6).to_i
+                sy=(40-y/6-z/4).to_i
+                if sx>=0 && x<160 then
+                    if d[sx]>sy then
+                        zz=((z+100)*0.035).to_i+1
+                        if [1,2,5,7].include?(zz) then
+                            dot(xscale*sx+xoffset,yscale*sy+yoffset,white)
+                        elsif  [2,3].include?(zz) or zz>=6 then
+                            dot(xscale*sx+xoffset,yscale*sy+yoffset,green)
+                        elsif zz>=4 then
+                            dot(xscale*sx+xoffset,yscale*sy+yoffset,purple)
+                        end
+                        d[sx]=sy
+                    end
+                end
+            end
+        end
+        Display.puts "Hit any key"
+        while !hit_any_key do 
+        sleep 0.05 
+        return if Blink.req_reload?
+        end
+        Display.puts "!"
+        sleep 0.5
+    end
+
+    puts "Picture"
+
+### picture load section
+    mrubycpng=
+        "\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x00\x19\x00\x00\x00\x19\b\x02\x00\x00\x00K\x8B\x124\x00\x00\x00\x06tRNS\x00\x80\x00\x00\x00\xFF\xF2BX\x8E\x00\x00\x00\tpHYs\x00\x00\v\x13\x00\x00\v\x13\x01\x00\x9A\x9C\x18\x00\x00\x03\x8CIDAT8\x8D\xB5T\xCFk\\U\x14>\xE7\xFEz\xEF\xCD\x9B\x99L&\xB1\xCE06M\x9345\x051\x16\n\x82?p%\xB5\x8B\xA8P\xFF\x00\x97\"\x05\x95n\xDC\xB8u\xE9F]\b\x82\xB8S\xD0\n\xD5\x8D\x05E\xA4U\xB0\xA5R\xC1\xC6\xD8Bc\xC4\x18\xD3\xC9\xFC\x9Ey\xF7\xDD\x1F\xC7\xC5\xB4\xC9\xCCt(\x04\xF4\xE3q\xE1\xBB\x87\xEF\xE3\xDC\xEF\xDDs\x01\xFE;\xE0\xBD[K2Z\t\x8Bc\n\x00\x00P62\xF6\xEC\x82o|b\xAB#%1\xC2\vL\x9C\xCDV\x8A\xC8g\x8C\xDA\x126A?X}\xC0\xCAC \x81\xC1c*\xBE\x96\xF4\xAE\xDB\xEE`\x95\r7\x89g\xB2\xA5\"\x8A\xC3iP\xB4B#\x85\xC4\x96t\x18\x12\x03\x80\xBC\xE73F\x02@\x87\xFB\re^\xCF\x96s\x8C\x0F\xCA\x87\xC8\x8B\xD1\xD4\xA9`r>U\x93\x96\xD7\x85\xE3\x04\vi\x10xl\n\x87\x80\x8B:d\x04)\xA3\xB5P;\xA0\f\xB2\n\x0F.\xA6\xCD1^\x8B\"z3\xAE<\xAC\xC3\xACc\xFD\x1E\xA7\xAD\xE8\xA7\xD6ct\xD0(I\xE8\x10\xD6B\xAD\x91\xFA\x92\nWm\xF2\xBF\xDBd\xC8+B\xF6^\xE6\xF0\xB2\xC9H\xBA\x13\xBA\xA0\xBD\xF4s\x9E\vB@\xB8\x19\xA4m\xE6\x06\x8F\xF2\x88\xCC\\6\xED\xBAw{\xD9O\x808f\xA3\xA1\xF0\xEEb=H\x9B\xCC\x03\xC0CF\xCE\xA4\x12@\x0EV\t\xE0\x10\x05\xB7@\xEFe\xFF7\xA5\xA7\xD3\xB5M2#F\x7F)\xB3\xCD\xADF_p|\xD2r\xE5q\xF0#\x0Fo\xE8\xF5\xEF\xDC\x9D\xC8\x86\xAEQ\t\xD5Gj\xEE\x18F}Z\x15\xEE\x96\xD2\x04P\xF0\xE2\xA0\x96U\xB2m\xF2\b\xD4\x97u\xC0\xBFe\xFE\xBC\xEA;\xBB\xF2\xD1+\x99E\xFE\xBE\x9C}\x86\xE5\xDB\xDC\xAF\x05\xDA\x03e\x88-$\xC1\rJ\xBE\xB2\xF5U\xEAy\x00\x01h\x80\xAE\xFAN\x8D\xEC\xA0\x96\x8Fx\xA5@\xE7}\xBD\xC0\x84\xCA0\a$\t\x8F\xE8p\x9B\xCC\xE7\xB6v\x81\x1A\xCFe&\x17U4\xAB\xC2\x92\x94\x97L+%\xBA\x9F\x17\x00x\x80o]3\x01Z\x96\xF1Q\x1D\xA0\xC7\x9F|\xE7S\xB7\xB3\x12\x17\x8F\xCBx\x9A\x89i&\xCA\\\x95\xB9\xBA\x98\xB6\x06\x85\xA33\xB4\x8Bs\xBDj\xD7\xB8w\xC5,\x00\x04\x80\x05\xE4\xD3\x9A\x1F\xB7\x19\x00\xB8\x11\xE8\xB2\x91\xBF\xA4\xDD\x11\xC9\x98\xBEvq\xD3'?\xF8\xF6I>QB\x99C\xFE\xB6\xD9\xAC\x91{\x92\xE5j\xDC}\x90\xFC\xF3\x8E\xD9\xBC\x8Fv<f1\xF8P\xCD?\xC1s}z\x8AO\x9E\xE4\x85}\xBB\xFC/@@\x81\xE3\x1F4\x85{\xC32vlFqT\x86+a\xF1\xDE\xFD\t&\xCE\xC4\xA5]\xCA9\xE2\xE3*7\xC5d\x81\x89\x02\x135o\x17E\xB4 \xA2\xDB\xDEV\x84\xEA\x90\x9F\x13!G\x9C\xE7a\x83\\\xDD\xDB#\"\xDA\xB9\xBB\xBE\x10\x16\xAF\x98N\x17|\x89\xCB\x86w<\xCF\xC4\xABq)D\xBE\xAC\xE2Ge\xBC\xEAz\xAF\xC4\xA5\xAA\xB7O\a\xF99\x11\xAE[\xFDr\xE6\xC0\xAF\xB6\xF7|T\xCC!/q\xB5,c@8\x1DM]J\xDB/ES\xE7u\xEDl\xB6\xFC \x93\xA6\x7F\xC6u\xA7\x7FL[\xD7L\xF7\xBA\xEDM\xA0\xE8\x92\xFB2\xD9\xF9,\xA9\xA6D%.c\xE4\x00\xB0\xE5\xCC\xCF\xA6{\x80\xCBsI\xF5\xB5l\xF9\xEB\xA4\xFET\x90\xFB>mf\x10[\xE4\xAF\x98\x8E&\xCF\t@\"\xFB\xC3\xE9\x04\xA8\xE9\xDD\x967\x8A\xB1\xDFl\xAFK~\xC3\xE9g\xC3\xC2\x86\xD7\xAB6)2\x91E\xF6E\xAF\xD6\"wB\xE5>\xEEm/\xC9\xE8\e\xDDlx\xE7\x00fxp\xD9\xB4\xF7\xF5?\x01\x00\xF2\x8C\x9FP\xD9}\xCB\xF6\x8B\x7F\x01/V\x8Fs\xBC\xFBA\xC6\x00\x00\x00\x00IEND\xAEB`\x82"
+
+### end of picture load section
+
+    Display.clear
+    Display.puts "picture test"
+    puts "Supported fonts: #{Font.names.inspect}"
+
+    Display.draw_pngstr(mrubycpng,30,60*yscale)
+
+    dimension=Display.dimension
+
+    Display.draw_pngstr(mrubycpng,dimension[0]/2,dimension[1]/2)
+
+
+    Display.puts "Hit any key to restart"
+    while !hit_any_key do 
+        sleep 0.05 
+    end
+end
+
+
+

--- a/src/m5u/c_canvas.cpp
+++ b/src/m5u/c_canvas.cpp
@@ -18,12 +18,12 @@ static void c_canvas_initialize(mrb_vm *vm, mrb_value *v, int argc) {
   *(M5Canvas **)v->instance->data = canvas;
 
   if (argc > 2) {
-    int depth = val_to_i(vm, v, GET_ARG(3), argc);
+    int depth = MRBC_ARG_I(3);
     canvas->setColorDepth(depth);
   }
   if (argc > 1) {
-    int width = val_to_i(vm, v, GET_ARG(1), argc);
-    int height = val_to_i(vm, v, GET_ARG(2), argc);
+    int width = MRBC_ARG_I(1);
+    int height = MRBC_ARG_I(2);
     auto ptr = canvas->createSprite(width, height);
     if (ptr == nullptr) {
       delete canvas;
@@ -38,8 +38,8 @@ static void c_canvas_initialize(mrb_vm *vm, mrb_value *v, int argc) {
 static void c_canvas_create_sprite(mrb_vm *vm, mrb_value *v, int argc) {
   M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
   if (argc == 2) {
-    int width = val_to_i(vm, v, GET_ARG(1), argc);
-    int height = val_to_i(vm, v, GET_ARG(2), argc);
+    int width = MRBC_ARG_I(1);
+    int height = MRBC_ARG_I(2);
     canvas->createSprite(width, height);
   } else {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "width must be specified");
@@ -51,8 +51,8 @@ static void c_canvas_push_sprite(mrb_vm *vm, mrb_value *v, int argc) {
   M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
 
   if (argc == 2) {
-    int x = val_to_i(vm, v, GET_ARG(1), argc);
-    int y = val_to_i(vm, v, GET_ARG(2), argc);
+    int x = MRBC_ARG_I(1);
+    int y = MRBC_ARG_I(2);
     canvas->pushSprite(x, y);
   } else if (argc == 3) {
     LovyanGFX *dst;
@@ -61,8 +61,8 @@ static void c_canvas_push_sprite(mrb_vm *vm, mrb_value *v, int argc) {
     } else {
       dst = &M5.Display;  // no error, fall on default
     }
-    int x = val_to_i(vm, v, GET_ARG(2), argc);
-    int y = val_to_i(vm, v, GET_ARG(3), argc);
+    int x = MRBC_ARG_I(2);
+    int y = MRBC_ARG_I(3);
     canvas->pushSprite(dst, x, y);
   } else {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "x-y");
@@ -161,25 +161,21 @@ static void class_canvas_draw_png(mrb_vm *vm, mrb_value *v, int argc) {
   M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
   draw_draw_png(canvas, vm, v, argc);
 }
-
 #endif  // USE_FILE_FUNCTION
 
-static void class_canvas_draw_bmpstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    M5Canvas *canvas =get_checked_data(M5Canvas,vm, v);
-    draw_draw_bmpstr(canvas,vm,v,argc);
+static void class_canvas_draw_bmpstr(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_bmpstr(canvas, vm, v, argc);
 }
 
-static void class_canvas_draw_jpgstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    M5Canvas *canvas =get_checked_data(M5Canvas,vm, v);
-    draw_draw_jpgstr(canvas,vm,v,argc);
+static void class_canvas_draw_jpgstr(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_jpgstr(canvas, vm, v, argc);
 }
 
-static void class_canvas_draw_pngstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    M5Canvas *canvas =get_checked_data(M5Canvas,vm, v);
-    draw_draw_pngstr(canvas,vm,v,argc);
+static void class_canvas_draw_pngstr(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_draw_pngstr(canvas, vm, v, argc);
 }
 
 static void class_canvas_set_rotation(mrb_vm *vm, mrb_value *v, int argc) {
@@ -223,10 +219,10 @@ void class_canvas_init() {
   mrbc_define_method(0, canvas_class, "draw_jpgfile", class_canvas_draw_jpg);
   mrbc_define_method(0, canvas_class, "draw_pngfile", class_canvas_draw_png);
 #endif  // USE_FILE_FUNCTION
-mrbc_define_method(0, canvas_class, "draw_bmpstr", class_canvas_draw_bmpstr);
-mrbc_define_method(0, canvas_class, "draw_jpgstr", class_canvas_draw_jpgstr);
-mrbc_define_method(0, canvas_class, "draw_pngstr", class_canvas_draw_pngstr);
-mrbc_define_method(0, canvas_class, "set_rotation",
+  mrbc_define_method(0, canvas_class, "draw_bmpstr", class_canvas_draw_bmpstr);
+  mrbc_define_method(0, canvas_class, "draw_jpgstr", class_canvas_draw_jpgstr);
+  mrbc_define_method(0, canvas_class, "draw_pngstr", class_canvas_draw_pngstr);
+  mrbc_define_method(0, canvas_class, "set_rotation",
                      class_canvas_set_rotation);
   mrbc_define_method(0, canvas_class, "dimension", c_canvas_get_dimension);
 }

--- a/src/m5u/c_display_button.cpp
+++ b/src/m5u/c_display_button.cpp
@@ -7,9 +7,9 @@
 
 static void class_display_color_value(mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 2) {
-    uint8_t r = val_to_i(vm, v, GET_ARG(1), argc);
-    uint8_t g = val_to_i(vm, v, GET_ARG(2), argc);
-    uint8_t b = val_to_i(vm, v, GET_ARG(3), argc);
+    uint8_t r = MRBC_ARG_I(1);
+    uint8_t g = MRBC_ARG_I(2);
+    uint8_t b = MRBC_ARG_I(3);
     uint16_t color = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
     SET_INT_RETURN(color);
   } else {
@@ -91,19 +91,16 @@ static void class_display_draw_png(mrb_vm *vm, mrb_value *v, int argc) {
 }
 #endif  // USE_FILE_FUNCTION
 
-static void class_display_draw_bmpstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_bmpstr(&M5.Display,vm,v,argc);
+static void class_display_draw_bmpstr(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_bmpstr(&M5.Display, vm, v, argc);
 }
 
-static void class_display_draw_jpgstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_jpgstr(&M5.Display,vm,v,argc);
+static void class_display_draw_jpgstr(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_jpgstr(&M5.Display, vm, v, argc);
 }
 
-static void class_display_draw_pngstr(mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_pngstr(&M5.Display,vm,v,argc);
+static void class_display_draw_pngstr(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pngstr(&M5.Display, vm, v, argc);
 }
 
 static void class_display_scroll(mrb_vm *vm, mrb_value *v, int argc) {
@@ -191,10 +188,14 @@ void class_display_button_init() {
   mrbc_define_method(0, class_display, "draw_jpgfile", class_display_draw_jpg);
   mrbc_define_method(0, class_display, "draw_pngfile", class_display_draw_png);
 #endif  // USE_FILE_FUNCTION
-  mrbc_define_method(0, class_display, "wait_display", class_display_wait_display);
-  mrbc_define_method(0, class_display, "draw_bmpstr", class_display_draw_bmpstr);
-  mrbc_define_method(0, class_display, "draw_jpgstr", class_display_draw_jpgstr);
-  mrbc_define_method(0, class_display, "draw_pngstr", class_display_draw_pngstr);
+  mrbc_define_method(0, class_display, "wait_display",
+                     class_display_wait_display);
+  mrbc_define_method(0, class_display, "draw_bmpstr",
+                     class_display_draw_bmpstr);
+  mrbc_define_method(0, class_display, "draw_jpgstr",
+                     class_display_draw_jpgstr);
+  mrbc_define_method(0, class_display, "draw_pngstr",
+                     class_display_draw_pngstr);
 
   mrbc_define_method(0, class_display, "scroll", class_display_scroll);
   mrbc_define_method(0, class_display, "set_rotation",

--- a/src/m5u/c_font.cpp
+++ b/src/m5u/c_font.cpp
@@ -1,118 +1,108 @@
 
 #include <M5Unified.h>
+
 #include "my_mrubydef.h"
 
 #ifdef USE_FONT
 
-#include "c_font.h"
-
-#include <vector>
 #include <lgfx/v1/lgfx_fonts.hpp>
+#include <vector>
 
+#include "c_font.h"
 #include "drawing.h"
 
 struct font_info {
-    const char* name;
-    const lgfx::v1::IFont* font;
+  const char *name;
+  const lgfx::v1::IFont *font;
 };
 
 std::vector<struct font_info> m5fonts;
 
-static void
-class_font_by_name(mrb_vm *vm, mrb_value *v, int argc)
-{
-    if(argc>0){
-        const char* fontname = val_to_s(vm, v, GET_ARG(1),argc);
-        //search the fonrname from m5fonts vector and return the order number of the font
-        for(int i=0; i<m5fonts.size(); i++){
-            if(strcmp(m5fonts[i].name, fontname)==0){
-                SET_INT_RETURN(i);
-                return;
-            }
-        }
+static void class_font_by_name(mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0) {
+    const char *fontname = MRBC_ARG_S(1);
+    // search the fonrname from m5fonts vector and return the order number of
+    // the font
+    for (int i = 0; i < m5fonts.size(); i++) {
+      if (strcmp(m5fonts[i].name, fontname) == 0) {
+        SET_INT_RETURN(i);
+        return;
+      }
     }
-    SET_FALSE_RETURN();
+  }
+  SET_FALSE_RETURN();
 }
 
-static void
-class_font_number(mrb_vm *vm, mrb_value *v, int argc)
-{
-    SET_INT_RETURN(m5fonts.size());
+static void class_font_number(mrb_vm *vm, mrb_value *v, int argc) {
+  SET_INT_RETURN(m5fonts.size());
 }
 
-static void
-class_font_names(mrb_vm *vm, mrb_value *v, int argc)
-{
-    mrbc_value ret = mrbc_array_new(vm, m5fonts.size());
-    for(int i=0; i<m5fonts.size(); i++){
-        mrbc_value str = mrbc_string_new_cstr(vm, m5fonts[i].name);
-        mrbc_array_set(&ret, i, &str);
-    }
-    SET_RETURN(ret);
+static void class_font_names(mrb_vm *vm, mrb_value *v, int argc) {
+  mrbc_value ret = mrbc_array_new(vm, m5fonts.size());
+  for (int i = 0; i < m5fonts.size(); i++) {
+    mrbc_value str = mrbc_string_new_cstr(vm, m5fonts[i].name);
+    mrbc_array_set(&ret, i, &str);
+  }
+  SET_RETURN(ret);
 }
 
-
-void draw_set_font(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc)
-{
-    if(argc>0){
-        if(GET_ARG(1).tt == MRBC_TT_INTEGER){
-            unsigned int  fontnumber = val_to_i(vm, v, GET_ARG(1),argc);
-            if(fontnumber < m5fonts.size()){
-                dst->setFont(m5fonts[fontnumber].font);
-                SET_TRUE_RETURN();
-                return;
-            }
-        } else if(GET_ARG(1).tt == MRBC_TT_STRING){   // by_name
-            const char* fontname = val_to_s(vm, v, GET_ARG(1),argc);
-            for(int i=0; i<m5fonts.size(); i++){
-                if(strcmp(m5fonts[i].name, fontname)==0){
-                    dst->setFont(m5fonts[i].font);
-                    SET_TRUE_RETURN();
-                    return;
-                }
-            }
+void draw_set_font(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  if (argc > 0) {
+    if (GET_ARG(1).tt == MRBC_TT_INTEGER) {
+      unsigned int fontnumber = MRBC_ARG_I(1);
+      if (fontnumber < m5fonts.size()) {
+        dst->setFont(m5fonts[fontnumber].font);
+        SET_TRUE_RETURN();
+        return;
+      }
+    } else if (GET_ARG(1).tt == MRBC_TT_STRING) {  // by_name
+      const char *fontname = MRBC_ARG_S(1);
+      for (int i = 0; i < m5fonts.size(); i++) {
+        if (strcmp(m5fonts[i].name, fontname) == 0) {
+          dst->setFont(m5fonts[i].font);
+          SET_TRUE_RETURN();
+          return;
         }
-    } 
-    SET_FALSE_RETURN();
+      }
+    }
+  }
+  SET_FALSE_RETURN();
 }
 
-static void class_display_set_font(mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_set_font(&M5.Display,vm,v,argc);
+static void class_display_set_font(mrb_vm *vm, mrb_value *v, int argc) {
+  draw_set_font(&M5.Display, vm, v, argc);
 }
 
-static void class_canvas_set_font(mrb_vm *vm, mrb_value *v, int argc)
-{
-    M5Canvas *canvas =get_checked_data(M5Canvas,vm, v);
-    draw_set_font(canvas,vm,v,argc);
+static void class_canvas_set_font(mrb_vm *vm, mrb_value *v, int argc) {
+  M5Canvas *canvas = get_checked_data(M5Canvas, vm, v);
+  draw_set_font(canvas, vm, v, argc);
 }
 
-uint8_t c_font_add(const char* fontname, const lgfx::v1::IFont* font)
-{
-    struct font_info fi;
-    fi.name = fontname;
-    fi.font = font;
-    m5fonts.push_back(fi);
-    return m5fonts.size()-1;
+uint8_t c_font_add(const char *fontname, const lgfx::v1::IFont *font) {
+  struct font_info fi;
+  fi.name = fontname;
+  fi.font = font;
+  m5fonts.push_back(fi);
+  return m5fonts.size() - 1;
 }
 
-void class_font_init()  // order dependency. Font must be defined after Display and Canvas
+void class_font_init()  // order dependency. Font must be defined after Display
+                        // and Canvas
 {
-    mrb_class *class_font = mrbc_define_class(0, "Font", mrbc_class_object);
-    mrbc_define_method(0, class_font, "by_name", class_font_by_name);  // old i/f
-    mrbc_define_method(0, class_font, "count", class_font_number);
-    mrbc_define_method(0, class_font, "names", class_font_names);
+  mrb_class *class_font = mrbc_define_class(0, "Font", mrbc_class_object);
+  mrbc_define_method(0, class_font, "by_name", class_font_by_name);  // old i/f
+  mrbc_define_method(0, class_font, "count", class_font_number);
+  mrbc_define_method(0, class_font, "names", class_font_names);
 
-    c_font_add("default", nullptr);
+  c_font_add("default", nullptr);
 #ifdef USE_EFONTJA10
-    c_font_add("efontJA_10", &efontJA_10);
-#endif // USE_EFONTJA10
+  c_font_add("efontJA_10", &efontJA_10);
+#endif  // USE_EFONTJA10
 
-
-    mrbc_class *class_display = mrbc_get_class_by_name("Display");
-    mrbc_class *class_canvas = mrbc_get_class_by_name("Canvas");
-    mrbc_define_method(0, class_display, "set_font", class_display_set_font);
-    mrbc_define_method(0, class_canvas, "set_font", class_canvas_set_font);
+  mrbc_class *class_display = mrbc_get_class_by_name("Display");
+  mrbc_class *class_canvas = mrbc_get_class_by_name("Canvas");
+  mrbc_define_method(0, class_display, "set_font", class_display_set_font);
+  mrbc_define_method(0, class_canvas, "set_font", class_canvas_set_font);
 }
 
-#endif // USE_FONT
+#endif  // USE_FONT

--- a/src/m5u/c_speaker.cpp
+++ b/src/m5u/c_speaker.cpp
@@ -1,67 +1,69 @@
+#include "c_speaker.h"
+
 #include <M5Unified.h>
 
 #include "my_mrubydef.h"
-#include "c_speaker.h"
 
 #ifdef USE_SPEAKER
 
 static void c_speaker_tone(mrb_vm *vm, mrb_value *v, int argc) {
-    if(argc<2){
-        mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments"); 
-        SET_FALSE_RETURN();
-        return;
-    }
+  if (argc < 2) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    SET_FALSE_RETURN();
+    return;
+  }
 
-    int freq = val_to_f(vm, v, GET_ARG(1), argc);
-    int duration = val_to_i(vm, v, GET_ARG(2), argc);
-    int channel = (argc>2)? val_to_i(vm, v, GET_ARG(3), argc) : -1;
-    bool stop_current = (argc<4 || ( GET_ARG(4).tt != MRBC_TT_NIL && GET_ARG(4).tt!=MRBC_TT_FALSE ));
-    M5.Speaker.tone(freq, duration,channel, stop_current);
+  int freq = MRBC_ARG_F(1);
+  int duration = MRBC_ARG_I(2);
+  int channel = (argc > 2) ? MRBC_ARG_I(3) : -1;
+  bool stop_current = (argc < 4 || (GET_ARG(4).tt != MRBC_TT_NIL &&
+                                    GET_ARG(4).tt != MRBC_TT_FALSE));
+  M5.Speaker.tone(freq, duration, channel, stop_current);
 }
 
 static void c_speaker_stop(mrb_vm *vm, mrb_value *v, int argc) {
-    if(argc>0) {
-        int channel = val_to_i(vm, v, GET_ARG(1), argc);
-        M5.Speaker.stop(channel);
-    } else {
-        M5.Speaker.stop();
-    }
+  if (argc > 0) {
+    int channel = MRBC_ARG_I(1);
+    M5.Speaker.stop(channel);
+  } else {
+    M5.Speaker.stop();
+  }
 }
 
 static void c_speaker_set_volume(mrb_vm *vm, mrb_value *v, int argc) {
-    if(argc<1){
-        mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments"); 
-        SET_FALSE_RETURN();
-        return;
-    }
+  if (argc < 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    SET_FALSE_RETURN();
+    return;
+  }
 
-    int volume = val_to_i(vm, v, GET_ARG(1), argc);
-    M5.Speaker.setVolume(volume);
+  int volume = MRBC_ARG_I(1);
+  M5.Speaker.setVolume(volume);
 }
 
 static void c_speaker_get_volume(mrb_vm *vm, mrb_value *v, int argc) {
-    int volume = M5.Speaker.getVolume();
-    SET_INT_RETURN(volume);
+  int volume = M5.Speaker.getVolume();
+  SET_INT_RETURN(volume);
 }
 
 static void c_speaker_is_playing(mrb_vm *vm, mrb_value *v, int argc) {
-    int channel = (argc>0)? val_to_i(vm, v, GET_ARG(1), argc) : -1;
-    if(M5.Speaker.isPlaying(channel)){
-        SET_TRUE_RETURN();
-    } else {
-        SET_FALSE_RETURN(); 
-    }
+  int channel = (argc > 0) ? MRBC_ARG_I(1) : -1;
+  if (M5.Speaker.isPlaying(channel)) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
 }
 
 void class_speaker_init() {
-    mrbc_class *speaker = mrbc_define_class(0,"Speaker", mrbc_class_object);
-    mrbc_define_method(0, speaker, "tone", c_speaker_tone);
-    mrbc_define_method(0, speaker, "stop", c_speaker_stop);
-    mrbc_define_method(0, speaker, "set_volume", c_speaker_set_volume);
-    mrbc_define_method(0, speaker, "volume=", c_speaker_set_volume);
-    mrbc_define_method(0, speaker, "get_volume", c_speaker_get_volume);
-    mrbc_define_method(0, speaker, "volume", c_speaker_set_volume);
-    mrbc_define_method(0, speaker, "is_playing?", c_speaker_is_playing);
+  mrbc_class *speaker = mrbc_define_class(0, "Speaker", mrbc_class_object);
+  mrbc_define_method(0, speaker, "tone", c_speaker_tone);
+  mrbc_define_method(0, speaker, "stop", c_speaker_stop);
+  mrbc_define_method(0, speaker, "set_volume", c_speaker_set_volume);
+  mrbc_define_method(0, speaker, "volume=", c_speaker_set_volume);
+  mrbc_define_method(0, speaker, "get_volume", c_speaker_get_volume);
+  mrbc_define_method(0, speaker, "volume", c_speaker_set_volume);
+  mrbc_define_method(0, speaker, "is_playing?", c_speaker_is_playing);
 }
 
-#endif // USE_SPEAKER
+#endif  // USE_SPEAKER

--- a/src/m5u/c_touch.cpp
+++ b/src/m5u/c_touch.cpp
@@ -1,102 +1,95 @@
-#include <M5Unified.h>
-#include "my_mrubydef.h"
 #include "c_touch.h"
+
+#include <M5Unified.h>
+
+#include "my_mrubydef.h"
 
 #ifdef USE_TOUCH
 
-static void
-class_touch_get_count(mrb_vm *vm, mrb_value *v, int argc)
-{
-    SET_INT_RETURN(M5.Touch.getCount());
+static void class_touch_get_count(mrb_vm *vm, mrb_value *v, int argc) {
+  SET_INT_RETURN(M5.Touch.getCount());
 }
 
-static void
-class_touch_get_detail(mrb_vm *vm, mrb_value *v, int argc)
-{
-    int no = (argc>0)? GET_INT_ARG(1) : 0;
-    if(no<M5.Touch.getCount()){
-        auto detail = M5.Touch.getDetail(no);
-        mrb_value ret = mrbc_array_new(vm, 5);
-        mrb_value a[5];
-        a[0] = mrbc_integer_value(detail.x);
-        a[1] = mrbc_integer_value(detail.y);
-        a[2] = mrbc_integer_value(detail.prev_x);
-        a[3] = mrbc_integer_value(detail.prev_y);
-        a[4] = mrbc_integer_value(detail.id); 
-        mrbc_array_set(&ret, 0, &a[0]);
-        mrbc_array_set(&ret, 1, &a[1]);
-        mrbc_array_set(&ret, 2, &a[2]);
-        mrbc_array_set(&ret, 3, &a[3]);
-        mrbc_array_set(&ret, 4, &a[4]);
-        SET_RETURN(ret);
-        return;
+static void class_touch_get_detail(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = (argc > 0) ? GET_INT_ARG(1) : 0;
+  if (no < M5.Touch.getCount()) {
+    auto detail = M5.Touch.getDetail(no);
+    mrb_value ret = mrbc_array_new(vm, 5);
+    mrb_value a[5];
+    a[0] = mrbc_integer_value(detail.x);
+    a[1] = mrbc_integer_value(detail.y);
+    a[2] = mrbc_integer_value(detail.prev_x);
+    a[3] = mrbc_integer_value(detail.prev_y);
+    a[4] = mrbc_integer_value(detail.id);
+    mrbc_array_set(&ret, 0, &a[0]);
+    mrbc_array_set(&ret, 1, &a[1]);
+    mrbc_array_set(&ret, 2, &a[2]);
+    mrbc_array_set(&ret, 3, &a[3]);
+    mrbc_array_set(&ret, 4, &a[4]);
+    SET_RETURN(ret);
+    return;
+  }
+  SET_NIL_RETURN();
+}
+
+static void class_touch_wasclicked(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = (argc > 0) ? MRBC_ARG_I(1) : 0;
+  if (no < M5.Touch.getCount()) {
+    if (M5.Touch.getDetail(no).wasClicked()) {
+      SET_TRUE_RETURN();
+      return;
     }
-    SET_NIL_RETURN();
+  }
+  SET_FALSE_RETURN();
 }
 
-static void class_touch_wasclicked(mrb_vm *vm, mrb_value *v, int argc)
-{
-    int no = (argc>0)? val_to_i(vm,v,GET_ARG(1),argc) : 0;
-    if(no<M5.Touch.getCount()){
-        if(M5.Touch.getDetail(no).wasClicked()){  
-            SET_TRUE_RETURN();
-            return;
-        }
+static void class_touch_ispressed(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = (argc > 0) ? MRBC_ARG_I(1) : 0;
+  if (no < M5.Touch.getCount()) {
+    if (M5.Touch.getDetail(no).isPressed()) {
+      SET_TRUE_RETURN();
+      return;
     }
-    SET_FALSE_RETURN();
+  }
+  SET_FALSE_RETURN();
 }
 
-static void class_touch_ispressed(mrb_vm *vm, mrb_value *v, int argc)
-{
-    int no = (argc>0)? val_to_i(vm,v,GET_ARG(1),argc)  : 0;
-    if(no<M5.Touch.getCount()){
-        if(M5.Touch.getDetail(no).isPressed()){
-            SET_TRUE_RETURN();
-            return;
-        }
+static void class_touch_isreleased(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = (argc > 0) ? MRBC_ARG_I(1) : 0;
+  if (no < M5.Touch.getCount()) {
+    if (M5.Touch.getDetail(no).isReleased()) {
+      SET_TRUE_RETURN();
+      return;
     }
-    SET_FALSE_RETURN();
+  }
+  SET_FALSE_RETURN();
 }
 
-static void class_touch_isreleased(mrb_vm *vm, mrb_value *v, int argc)
-{
-    int no = (argc>0)?  val_to_i(vm,v,GET_ARG(1),argc)  : 0;
-    if(no<M5.Touch.getCount()){
-        if(M5.Touch.getDetail(no).isReleased()){
-            SET_TRUE_RETURN();
-            return;
-        }
+static void class_touch_isholding(mrb_vm *vm, mrb_value *v, int argc) {
+  int no = (argc > 0) ? MRBC_ARG_I(1) : 0;
+  if (no < M5.Touch.getCount()) {
+    if (M5.Touch.getDetail(no).isHolding()) {
+      SET_TRUE_RETURN();
+      return;
     }
-    SET_FALSE_RETURN();
+  }
+  SET_FALSE_RETURN();
 }
 
-static void class_touch_isholding(mrb_vm *vm, mrb_value *v, int argc)
-{
-    int no = (argc>0)?  val_to_i(vm,v,GET_ARG(1),argc)  : 0;
-    if(no<M5.Touch.getCount()){
-        if(M5.Touch.getDetail(no).isHolding()){
-            SET_TRUE_RETURN();
-            return;
-        }
-    }
-    SET_FALSE_RETURN();
+void class_touch_init() {
+  if (M5.Touch.isEnabled()) {
+    mrb_class *class_touch;
+    class_touch = mrbc_define_class(0, "Touch", mrbc_class_object);
+    mrbc_define_method(0, class_touch, "available?", true_return);
+    mrbc_define_method(0, class_touch, "count", class_touch_get_count);
+    mrbc_define_method(0, class_touch, "detail", class_touch_get_detail);
+    mrbc_define_method(0, class_touch, "was_clicked?", class_touch_wasclicked);
+    mrbc_define_method(0, class_touch, "is_pressed?", class_touch_ispressed);
+    mrbc_define_method(0, class_touch, "is_released?", class_touch_isreleased);
+    mrbc_define_method(0, class_touch, "is_holding?", class_touch_isholding);
+  } else {
+    mrbc_set_const(mrbc_str_to_symid("Touch"), &failed_object);
+  }
 }
 
-
-void class_touch_init(){
-    if(M5.Touch.isEnabled()){
-        mrb_class *class_touch;
-        class_touch = mrbc_define_class(0, "Touch", mrbc_class_object);
-        mrbc_define_method(0, class_touch, "available?", true_return);
-        mrbc_define_method(0, class_touch, "count", class_touch_get_count);
-        mrbc_define_method(0, class_touch, "detail", class_touch_get_detail);
-        mrbc_define_method(0, class_touch, "was_clicked?", class_touch_wasclicked);
-        mrbc_define_method(0, class_touch, "is_pressed?", class_touch_ispressed);
-        mrbc_define_method(0, class_touch, "is_released?", class_touch_isreleased);
-        mrbc_define_method(0, class_touch, "is_holding?", class_touch_isholding);
-    } else {
-        mrbc_set_const(mrbc_str_to_symid("Touch"), &failed_object);
-    }
-}
-
-#endif // USE_TOUCH
+#endif  // USE_TOUCH

--- a/src/m5u/c_utils.cpp
+++ b/src/m5u/c_utils.cpp
@@ -7,7 +7,7 @@
 #ifdef USE_TEMPORAL_RANDOM_FUNCTION
 static void class_utils_randomseed(mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 0) {
-    randomSeed(val_to_i(vm, v, GET_ARG(1), argc));
+    randomSeed(MRBC_ARG_I(1));
   } else {
     randomSeed(analogRead(0));
   }
@@ -16,10 +16,9 @@ static void class_utils_randomseed(mrb_vm *vm, mrb_value *v, int argc) {
 
 static void class_utils_random(mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 1) {
-    SET_INT_RETURN(random(val_to_i(vm, v, GET_ARG(1), argc),
-                          val_to_i(vm, v, GET_ARG(2), argc)));
+    SET_INT_RETURN(random(MRBC_ARG_I(1), MRBC_ARG_I(2)));
   } else if (argc > 0) {
-    SET_INT_RETURN(random(val_to_i(vm, v, GET_ARG(1), argc)));
+    SET_INT_RETURN(random(MRBC_ARG_I(1)));
   } else {
     SET_INT_RETURN(random());
   }
@@ -27,12 +26,10 @@ static void class_utils_random(mrb_vm *vm, mrb_value *v, int argc) {
 #endif  // USE_TEMPORAL_RANDOM_FUNCTION
 
 static void class_utils_millis(mrb_vm *vm, mrb_value *v, int argc) {
-  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にも程がある
+  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にもう程がある
 }
 static void class_utils_delay(mrb_vm *vm, mrb_value *v, int argc) {
-  if (argc > 0)
-    vTaskDelay(
-        val_to_i(vm, v, GET_ARG(1), argc));  // 後で直す。適当にも程がある
+  if (argc > 0) vTaskDelay(MRBC_ARG_I(1));  // 後で直す。適当にもう程がある
 }
 
 void class_utils_init() {

--- a/src/m5u/c_utils.cpp
+++ b/src/m5u/c_utils.cpp
@@ -26,10 +26,10 @@ static void class_utils_random(mrb_vm *vm, mrb_value *v, int argc) {
 #endif  // USE_TEMPORAL_RANDOM_FUNCTION
 
 static void class_utils_millis(mrb_vm *vm, mrb_value *v, int argc) {
-  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にもう程がある
+  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にも程がある
 }
 static void class_utils_delay(mrb_vm *vm, mrb_value *v, int argc) {
-  if (argc > 0) vTaskDelay(MRBC_ARG_I(1));  // 後で直す。適当にもう程がある
+  if (argc > 0) vTaskDelay(MRBC_ARG_I(1));  // 後で直す。適当にも程がある
 }
 
 void class_utils_init() {

--- a/src/m5u/c_utils.cpp
+++ b/src/m5u/c_utils.cpp
@@ -26,10 +26,11 @@ static void class_utils_random(mrb_vm *vm, mrb_value *v, int argc) {
 #endif  // USE_TEMPORAL_RANDOM_FUNCTION
 
 static void class_utils_millis(mrb_vm *vm, mrb_value *v, int argc) {
-  SET_INT_RETURN(xTaskGetTickCount());  // 後で直す。適当にも程がある
+  SET_INT_RETURN(xTaskGetTickCount() * 1000 /
+                 configTICK_RATE_HZ);  // note: overflow not considered
 }
 static void class_utils_delay(mrb_vm *vm, mrb_value *v, int argc) {
-  if (argc > 0) vTaskDelay(MRBC_ARG_I(1));  // 後で直す。適当にも程がある
+  if (argc > 0) vTaskDelay(pdMS_TO_TICKS(MRBC_ARG_I(1)));
 }
 
 void class_utils_init() {

--- a/src/m5u/drawing.cpp
+++ b/src/m5u/drawing.cpp
@@ -10,7 +10,7 @@
 
 void draw_set_text_size(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 0) {
-    int sz = val_to_i(vm, v, GET_ARG(1), argc);
+    int sz = MRBC_ARG_I(1);
     dst->setTextSize(sz);
     SET_TRUE_RETURN();
   } else {
@@ -21,7 +21,7 @@ void draw_set_text_size(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 void draw_print(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   int r = 0;
   for (int i = 1; i <= argc; i++) {
-    const char *str = val_to_s(vm, v, GET_ARG(i), argc);
+    const char *str = MRBC_ARG_S(i);
     r += dst->print(str);
   }
   SET_INT_RETURN(r);
@@ -33,7 +33,7 @@ void draw_puts(LovyanGFX *dst, mrb_vm *vm, mrb_value v[], int argc) {
     r += dst->println();
   }
   for (int i = 1; i <= argc; i++) {
-    const char *str = val_to_s(vm, v, GET_ARG(i), argc);
+    const char *str = MRBC_ARG_S(i);
     r += dst->println(str);
   }
   SET_INT_RETURN(r);
@@ -42,7 +42,7 @@ void draw_puts(LovyanGFX *dst, mrb_vm *vm, mrb_value v[], int argc) {
 void draw_clear(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   int color = 0;
   if (argc > 0) {
-    color = val_to_i(vm, v, GET_ARG(1), argc);
+    color = MRBC_ARG_I(1);
   }
 
   dst->clearDisplay(color);
@@ -52,11 +52,10 @@ void draw_clear(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_set_text_color(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 1) {
-    dst->setTextColor(val_to_i(vm, v, GET_ARG(1), argc),
-                      val_to_i(vm, v, GET_ARG(2), argc));
+    dst->setTextColor((int8_t)MRBC_ARG_I(1), (int8_t)MRBC_ARG_I(2));
     SET_TRUE_RETURN();
   } else if (argc > 0) {
-    dst->setTextColor(val_to_i(vm, v, GET_ARG(1), argc));
+    dst->setTextColor((int16_t)MRBC_ARG_I(1));
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
@@ -65,8 +64,7 @@ void draw_set_text_color(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_set_cursor(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 1) {
-    dst->setCursor(val_to_i(vm, v, GET_ARG(1), argc),
-                   val_to_i(vm, v, GET_ARG(2), argc));
+    dst->setCursor(MRBC_ARG_I(1), MRBC_ARG_I(2));
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
@@ -98,11 +96,11 @@ void draw_get_dimension(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 #ifdef USE_DISPLAY_GRAPHICS
 void draw_fill_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 4) {
-    int x = val_to_i(vm, v, GET_ARG(1), argc);
-    int y = val_to_i(vm, v, GET_ARG(2), argc);
-    int w = val_to_i(vm, v, GET_ARG(3), argc);
-    int h = val_to_i(vm, v, GET_ARG(4), argc);
-    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    int x = MRBC_ARG_I(1);
+    int y = MRBC_ARG_I(2);
+    int w = MRBC_ARG_I(3);
+    int h = MRBC_ARG_I(4);
+    int color = MRBC_ARG_I(5);
     dst->fillRect(x, y, w, h, color);
     SET_TRUE_RETURN();
   } else {
@@ -112,11 +110,11 @@ void draw_fill_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_draw_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 4) {
-    int x = val_to_i(vm, v, GET_ARG(1), argc);
-    int y = val_to_i(vm, v, GET_ARG(2), argc);
-    int w = val_to_i(vm, v, GET_ARG(3), argc);
-    int h = val_to_i(vm, v, GET_ARG(4), argc);
-    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    int x = MRBC_ARG_I(1);
+    int y = MRBC_ARG_I(2);
+    int w = MRBC_ARG_I(3);
+    int h = MRBC_ARG_I(4);
+    int color = MRBC_ARG_I(5);
     dst->drawRect(x, y, w, h, color);
     SET_TRUE_RETURN();
   } else {
@@ -126,11 +124,11 @@ void draw_draw_rect(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_draw_line(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 4) {
-    int x1 = val_to_i(vm, v, GET_ARG(1), argc);
-    int y1 = val_to_i(vm, v, GET_ARG(2), argc);
-    int x2 = val_to_i(vm, v, GET_ARG(3), argc);
-    int y2 = val_to_i(vm, v, GET_ARG(4), argc);
-    int color = val_to_i(vm, v, GET_ARG(5), argc);
+    int x1 = MRBC_ARG_I(1);
+    int y1 = MRBC_ARG_I(2);
+    int x2 = MRBC_ARG_I(3);
+    int y2 = MRBC_ARG_I(4);
+    int color = MRBC_ARG_I(5);
     dst->drawLine(x1, y1, x2, y2, color);
     SET_TRUE_RETURN();
   } else {
@@ -140,10 +138,10 @@ void draw_draw_line(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_flll_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 3) {
-    int x = val_to_i(vm, v, GET_ARG(1), argc);
-    int y = val_to_i(vm, v, GET_ARG(2), argc);
-    int r = val_to_i(vm, v, GET_ARG(3), argc);
-    int color = val_to_i(vm, v, GET_ARG(4), argc);
+    int x = MRBC_ARG_I(1);
+    int y = MRBC_ARG_I(2);
+    int r = MRBC_ARG_I(3);
+    int color = MRBC_ARG_I(4);
     dst->fillCircle(x, y, r, color);
     SET_TRUE_RETURN();
   } else {
@@ -153,10 +151,10 @@ void draw_flll_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_draw_circle(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 3) {
-    int x = val_to_i(vm, v, GET_ARG(1), argc);
-    int y = val_to_i(vm, v, GET_ARG(2), argc);
-    int r = val_to_i(vm, v, GET_ARG(3), argc);
-    int color = val_to_i(vm, v, GET_ARG(4), argc);
+    int x = MRBC_ARG_I(1);
+    int y = MRBC_ARG_I(2);
+    int r = MRBC_ARG_I(3);
+    int color = MRBC_ARG_I(4);
     dst->drawCircle(x, y, r, color);
     SET_TRUE_RETURN();
   } else {
@@ -172,7 +170,7 @@ static void draw_draw_pic_file(LovyanGFX *dst, draw_pic_type t, mrb_vm *vm,
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "too few arguments");
     return;
   }
-  mrbc_value file = GET_ARG(1);
+  mrbc_value file = MRBC_ARG(1);
   int r = mrbc_obj_is_kind_of(&file, class_file);
   if (r == 0) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "not a file");
@@ -180,8 +178,8 @@ static void draw_draw_pic_file(LovyanGFX *dst, draw_pic_type t, mrb_vm *vm,
     return;
   }
   File *f = *(File **)file.instance->data;
-  int x = val_to_i(vm, v, GET_ARG(2), argc);
-  int y = val_to_i(vm, v, GET_ARG(3), argc);
+  int x = MRBC_ARG_I(2);
+  int y = MRBC_ARG_I(3);
 
   draw_draw_pic_stream(dst, t, f, x, y);
 
@@ -202,59 +200,58 @@ void draw_draw_png(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 #endif  // USE_FILE_FUNCTION
 
-static void draw_draw_pic_mem(LovyanGFX *dst, draw_pic_type t, const uint8_t * mem, size_t memsize, int x, int y){
-  switch(t){
-      case bmp:
-          dst->drawBmp(mem,memsize,x,y);
-          break;
-      case jpg:
-          dst->drawJpg(mem,memsize,x,y);
-          break;
-      case png:
-          dst->drawPng(mem,memsize,x,y);
-          break;
+static void draw_draw_pic_mem(LovyanGFX *dst, draw_pic_type t,
+                              const uint8_t *mem, size_t memsize, int x,
+                              int y) {
+  switch (t) {
+    case bmp:
+      dst->drawBmp(mem, memsize, x, y);
+      break;
+    case jpg:
+      dst->drawJpg(mem, memsize, x, y);
+      break;
+    case png:
+      dst->drawPng(mem, memsize, x, y);
+      break;
   }
 }
-void draw_draw_pic_str(LovyanGFX *dst, draw_pic_type t, mrb_vm *vm, mrb_value *v, int argc)
-{
-    if(argc<3){
-        mrbc_raise(vm, MRBC_CLASS(ArgumentError),"too few arguments");
-        return;
-    }
-    if(GET_ARG(1).tt != MRBC_TT_STRING){
-        mrbc_raise(vm, MRBC_CLASS(ArgumentError),"not a string");
-        SET_FALSE_RETURN();
-        return;
-    }
-    const uint8_t *mem = GET_ARG(1).string->data;
-    size_t memsize = GET_ARG(1).string->size;
+void draw_draw_pic_str(LovyanGFX *dst, draw_pic_type t, mrb_vm *vm,
+                       mrb_value *v, int argc) {
+  if (argc < 3) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "too few arguments");
+    return;
+  }
+  if (GET_ARG(1).tt != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "not a string");
+    SET_FALSE_RETURN();
+    return;
+  }
+  const uint8_t *mem = GET_ARG(1).string->data;
+  size_t memsize = GET_ARG(1).string->size;
 
-    int x = val_to_i(vm, v, GET_ARG(2),argc);
-    int y = val_to_i(vm, v, GET_ARG(3),argc);
+  int x = MRBC_ARG_I(2);
+  int y = MRBC_ARG_I(3);
 
-    draw_draw_pic_mem(dst,t, mem, memsize,x,y);
-    
-    SET_TRUE_RETURN();
+  draw_draw_pic_mem(dst, t, mem, memsize, x, y);
+
+  SET_TRUE_RETURN();
 }
 
-void draw_draw_bmpstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_pic_str(dst,bmp,vm,v,argc);
+void draw_draw_bmpstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_str(dst, bmp, vm, v, argc);
 }
 
-void draw_draw_jpgstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_pic_str(dst, jpg,vm,v,argc);
+void draw_draw_jpgstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_str(dst, jpg, vm, v, argc);
 }
 
-void draw_draw_pngstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc)
-{
-    draw_draw_pic_str(dst, png,vm,v,argc);
+void draw_draw_pngstr(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
+  draw_draw_pic_str(dst, png, vm, v, argc);
 }
 
 void draw_set_rotation(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc > 0) {
-    int rotation = val_to_i(vm, v, GET_ARG(1), argc);
+    int rotation = MRBC_ARG_I(1);
     dst->setRotation(rotation);
     SET_TRUE_RETURN();
   } else {
@@ -264,8 +261,8 @@ void draw_set_rotation(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
 
 void draw_scroll(LovyanGFX *dst, mrb_vm *vm, mrb_value *v, int argc) {
   if (argc == 2) {
-    int dx = val_to_i(vm, v, GET_ARG(1), argc);
-    int dy = val_to_i(vm, v, GET_ARG(2), argc);
+    int dx = MRBC_ARG_I(1);
+    int dy = MRBC_ARG_I(2);
     dst->scroll(dx, dy);
   } else {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "dx and dy");

--- a/src/m5u/my_mrubydef.h
+++ b/src/m5u/my_mrubydef.h
@@ -14,7 +14,7 @@
 
 #include "c_m5.h"
 #include "mrubyc.h"
-
+/*
 inline const char *val_to_s(mrb_vm *vm, mrb_value *v, mrbc_value &recv,
                             int regofs) {
   const char *str;
@@ -47,6 +47,7 @@ inline float val_to_f(mrb_vm *vm, mrb_value *v, mrbc_value &recv, int regofs) {
   }
   return f;
 }
+*/
 
 inline void put_null_data(mrb_value *v) {
   *(uint8_t **)v->instance->data = nullptr;


### PR DESCRIPTION
**Title:**  
Replace val_to_X() and GET_ARG() with MRBC_ARG_X() and MRBC_TO_X() macros in src/m5u

**Description:**  
This PR refactors all files in `src/m5u` to use the new `MRBC_ARG_X()` and `MRBC_TO_X()` macros for argument conversion and access, replacing the previous `val_to_X()` and `GET_ARG()` functions/macros.

- Follows the approach and changes from upstream mrubyc-m5 commit: [5233d9e](https://github.com/nyasu3w/mrubyc-m5/commit/5233d9eb2c443ab90e9ca3c8d5a185c00a94c5e8)
- Affected files:  
  - c_canvas.cpp  
  - c_display_button.cpp  
  - c_font.cpp  
  - c_speaker.cpp  
  - c_touch.cpp  
  - c_utils.cpp

**Purpose:**  
Keeps the code in sync with upstream and improves code consistency and clarity by standardizing argument access macros.